### PR TITLE
Feat/issue #6

### DIFF
--- a/src/page/DebateRoom/BottomNavBar/BottomNavBar.jsx
+++ b/src/page/DebateRoom/BottomNavBar/BottomNavBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './BottomNavBar.module.css';
 
-export const BottomNavBar = ({ roomNumber, onSendMessage, message, setMessage }) => {
+export const BottomNavBar = ({ roomNumber, onSendMessage, message, setMessage, isThread }) => {
     const handleInputChange = (e) => {
         setMessage(e.target.value);
     };
@@ -20,7 +20,7 @@ export const BottomNavBar = ({ roomNumber, onSendMessage, message, setMessage })
             <input
                 type="text"
                 className={styles.inputField}
-                placeholder={`${roomNumber}번 토론방에 메시지 보내기`}
+                placeholder={isThread ? '답글 추가하기':`${roomNumber}번 토론방에 메시지 보내기`}
                 value={message}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}

--- a/src/page/DebateRoom/BottomNavBar/BottomNavBar.module.css
+++ b/src/page/DebateRoom/BottomNavBar/BottomNavBar.module.css
@@ -3,7 +3,7 @@
     position: fixed;
     bottom: 0;
     left: 0;
-    width: 100%;
+    width: 95%;
     background-color: #fff;
     border-top-left-radius: 15px;
     border-top-right-radius: 15px;

--- a/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
+++ b/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
@@ -1,4 +1,4 @@
-import React, { useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import { useParams } from 'react-router-dom';
 import { useStomp } from '../../../context/StompContext';
 import {MessageItem} from "../MessageItem/MessageItem";
@@ -25,6 +25,16 @@ export function DebateRoom() {
             disagreeRatio,
             handlePutPreference } = useMessages(roomId, stompClient);
 
+    const messagesEndRef = useRef(null);
+
+    const scrollToBottom = () => {
+        messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    };
+
+    useEffect(() => {
+        // 메시지 불러오는 로직 여기에 추가
+        scrollToBottom();
+    }, [messages]);
 
     function sendMessage() {
         if (stompClient) {
@@ -71,7 +81,7 @@ export function DebateRoom() {
                 message={currentMessage}
                 handlePutPreference={handlePutPreference}
             />
-
+            <div ref={messagesEndRef}/>
             {!isModalOpen && (
                 <div className={styles.bottomMargin}>
                     <BottomNavBar roomNumber={roomId}

--- a/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
+++ b/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
@@ -1,7 +1,6 @@
 import React, { useState} from 'react';
 import { useParams } from 'react-router-dom';
 import { useStomp } from '../../../context/StompContext';
-import { fetchUtil } from "../../../utils/fetchUtil";
 import {MessageItem} from "../MessageItem/MessageItem";
 import {TopNavBar} from "../TopNavBar/TopNavBar";
 import styles from './DebateRoom.module.css';
@@ -35,7 +34,6 @@ export function DebateRoom() {
         }
     }
 
-
     const handleOpenMessageThread = (message) => {
         setCurrentMessage(message);
         setIsModalOpen(true);
@@ -48,15 +46,7 @@ export function DebateRoom() {
     const handleNavLeftOnClick = () =>{
         navigate(-1)
     }
-    // async function handleShowComments(messageId){
-    //     const prevThreads = await fetchUtil(`/message/thread/${messageId}`, {
-    //         method: 'GET'
-    //     });
-    //     setMessageThreads(prevThread => ({
-    //         ...prevThread,
-    //         [messageId]: prevThreads.data
-    //     }));
-    // }
+
     return (
         <div>
             <TopNavBar handleOnClick={handleNavLeftOnClick}>
@@ -80,9 +70,8 @@ export function DebateRoom() {
                 close={handleCloseMessageThread}
                 message={currentMessage}
                 handlePutPreference={handlePutPreference}
-            >
-                {/* 모달 내부에 들어갈 내용 */}
-            </MessageThread>
+            />
+
             {!isModalOpen && (
                 <div className={styles.bottomMargin}>
                     <BottomNavBar roomNumber={roomId}

--- a/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
+++ b/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
@@ -74,16 +74,24 @@ export function DebateRoom() {
                     </div>
                 ))}
             </div>
-            <MessageThread roomId={roomId} isOpen={isModalOpen} close={handleCloseMessageThread} message={currentMessage}>
+            <MessageThread
+                roomId={roomId}
+                isOpen={isModalOpen}
+                close={handleCloseMessageThread}
+                message={currentMessage}
+                handlePutPreference={handlePutPreference}
+            >
                 {/* 모달 내부에 들어갈 내용 */}
             </MessageThread>
-            <div className={styles.bottomMargin}>
-                <BottomNavBar roomNumber={roomId}
-                              onSendMessage={sendMessage}
-                              message={yourMessage}
-                              setMessage={setYourMessage}
-                />
-            </div>
+            {!isModalOpen && (
+                <div className={styles.bottomMargin}>
+                    <BottomNavBar roomNumber={roomId}
+                                  onSendMessage={sendMessage}
+                                  message={yourMessage}
+                                  setMessage={setYourMessage}
+                    />
+                </div>
+            )}
         </div>
-);
+    );
 }

--- a/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
+++ b/src/page/DebateRoom/DebateRoom/DebateRoom.jsx
@@ -18,12 +18,15 @@ export function DebateRoom() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const navigate = useNavigate();
 
+
     const { messages,
             agreeNum,
             disagreeNum,
             agreeRatio,
             disagreeRatio,
-            handlePutPreference } = useMessages(roomId, stompClient);
+            handlePutPreference,
+            forceRefresh
+    } = useMessages(roomId, stompClient);
 
     const messagesEndRef = useRef(null);
 
@@ -74,12 +77,13 @@ export function DebateRoom() {
                     </div>
                 ))}
             </div>
-            <MessageThread
-                roomId={roomId}
-                isOpen={isModalOpen}
-                close={handleCloseMessageThread}
-                message={currentMessage}
-                handlePutPreference={handlePutPreference}
+            <MessageThread key={messages.messageId}
+                           roomId={roomId}
+                           isOpen={isModalOpen}
+                           close={handleCloseMessageThread}
+                           message={currentMessage}
+                           handlePutPreference={handlePutPreference}
+                           forceRefresh={forceRefresh}
             />
             <div ref={messagesEndRef}/>
             {!isModalOpen && (

--- a/src/page/DebateRoom/DebateRoom/DebateRoom.module.css
+++ b/src/page/DebateRoom/DebateRoom/DebateRoom.module.css
@@ -5,3 +5,9 @@
 .bottomMargin {
     margin-bottom: 70px; /* 네비게이션 바의 높이만큼 패딩 추가 */
 }
+
+
+
+.smallText {
+    font-size: small;
+}

--- a/src/page/DebateRoom/MessageItem/MessageItem.jsx
+++ b/src/page/DebateRoom/MessageItem/MessageItem.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import styles from './MessageItem.module.css';
 
-export const MessageItem = ({ message, handlePutPreference, isThread }) => {
+export const MessageItem = ({ message, handlePutPreference, isThread}) => {
 
     const handleLikeClick = (e) => {
         e.stopPropagation();
@@ -10,7 +10,7 @@ export const MessageItem = ({ message, handlePutPreference, isThread }) => {
     };
 
     return (
-        <div className={`${styles.messageContainer} ${isThread ? styles.thread: ""}`} key={message.messageId}>
+        <div className={`${styles.messageContainer}`} key={message.messageId}>
             <div className={styles.header}>
                 <img src={message.profileImage} alt="" className={styles.profileImage}/>
                 <div className={styles.flexContainer}>

--- a/src/page/DebateRoom/MessageItem/MessageItem.jsx
+++ b/src/page/DebateRoom/MessageItem/MessageItem.jsx
@@ -2,7 +2,12 @@
 import React from 'react';
 import styles from './MessageItem.module.css';
 
-export const MessageItem = ({ message, handlePutPreference }) => {
+export const MessageItem = ({ message, handlePutPreference, isThread }) => {
+
+    const handleLikeClick = (e) => {
+        e.stopPropagation();
+        handlePutPreference(message.messageId, message.position, message.likesNum)
+    };
 
     return (
         <div className={styles.messageContainer} key={message.messageId}>
@@ -15,15 +20,16 @@ export const MessageItem = ({ message, handlePutPreference }) => {
                     </div>
                     <p className={styles.content}>{message.content}</p>
                     <div className={styles.reactions}>
-                        <div className={`${styles.position} ${message.position === 'DISAGREE' ? styles.oppose : ''}`}>
+                        <div className={`${styles.position}`}>
                             {message.position}
                         </div>
-                        <button onClick={() => handlePutPreference(message.messageId, message.position, message.likesNum)}>👍</button>
+                        <button onClick={(e) => handleLikeClick(e)}>👍</button>
 
-                        {message.likesNum > 0 && (
+
+                        {!isThread && message.likesNum > 0 && (
                             <div>{message.likesNum}</div>
                         )}
-                        {message.threadNum > 0 && (
+                        {!isThread && message.threadNum > 0 && (
                             <div className={styles.replies}>답글 {message.threadNum}</div>
                         )}
                     </div>

--- a/src/page/DebateRoom/MessageItem/MessageItem.jsx
+++ b/src/page/DebateRoom/MessageItem/MessageItem.jsx
@@ -6,11 +6,11 @@ export const MessageItem = ({ message, handlePutPreference, isThread }) => {
 
     const handleLikeClick = (e) => {
         e.stopPropagation();
-        handlePutPreference(message.messageId, message.position, message.likesNum)
+        handlePutPreference(message.messageId, message.position);
     };
 
     return (
-        <div className={styles.messageContainer} key={message.messageId}>
+        <div className={`${styles.messageContainer} ${isThread ? styles.thread: ""}`} key={message.messageId}>
             <div className={styles.header}>
                 <img src={message.profileImage} alt="" className={styles.profileImage}/>
                 <div className={styles.flexContainer}>
@@ -24,9 +24,7 @@ export const MessageItem = ({ message, handlePutPreference, isThread }) => {
                             {message.position}
                         </div>
                         <button onClick={(e) => handleLikeClick(e)}>👍</button>
-
-
-                        {!isThread && message.likesNum > 0 && (
+                        {message.likesNum > 0 && (
                             <div>{message.likesNum}</div>
                         )}
                         {!isThread && message.threadNum > 0 && (

--- a/src/page/DebateRoom/MessageItem/MessageItem.module.css
+++ b/src/page/DebateRoom/MessageItem/MessageItem.module.css
@@ -73,3 +73,7 @@
     display: flex;
     flex-direction: column;
 }
+
+.thread {
+    z-index: 999;
+}

--- a/src/page/DebateRoom/MessageThread/MessageThread.jsx
+++ b/src/page/DebateRoom/MessageThread/MessageThread.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import styles from './MessageThread.module.css';
 import {TopNavBar} from "../TopNavBar/TopNavBar";
+import {MessageItem} from "../MessageItem/MessageItem";
 
-export function MessageThread({ roomId, isOpen, close, message, children }){
+export function MessageThread({ roomId, isOpen, close, message, handlePutPreference, children }){
     useEffect(() => {
         if (isOpen) {
             document.body.style.overflow = 'hidden';
@@ -13,20 +14,26 @@ export function MessageThread({ roomId, isOpen, close, message, children }){
 
     if (!isOpen) return null;
 
-
-
     return (
-        <div >
+        <div>
             <TopNavBar handleOnClick={close}>
                 <div>답글</div>
-                <div className={styles.smallText}>{`${roomId}번 토론방 ${message.position}`}</div>
+                <div className={styles.smallText}>{`${roomId}번 토론방`}</div>
             </TopNavBar>
-            <div>
-                <p>{message?.content}</p>
-                {/*<p>{message?.repliesCount}개의 댓글</p>*/}
-                {children}
+            <div className={styles.fixedMessageItem}>
+                <MessageItem
+                    message={message}
+                    isThread={true}
+                    handlePutPreference={handlePutPreference}
+                />
+                <div>
+                    #개의 답글
+                </div>
+
             </div>
+            <div className={styles.modalOverlay}></div>
+
         </div>
     );
-};
+}
 

--- a/src/page/DebateRoom/MessageThread/MessageThread.jsx
+++ b/src/page/DebateRoom/MessageThread/MessageThread.jsx
@@ -10,13 +10,13 @@ import {ThreadItem} from "./ThreadItem";
 export function MessageThread({ roomId, isOpen, close, message, handlePutPreference}){
     const stompClient = useStomp();
     const threads = useThread(message? message.messageId:null, stompClient, isOpen)
-    const [yourMessage, setYourMessage] = useState('');
+    const [threadMessage, setThreadMessage] = useState('');
 
-    function sendMessage() {
+    function sendThreadMessage() {
         if (stompClient) {
             stompClient.send(`/pub/message/${message.messageId}`, {},
-                JSON.stringify({roomId: roomId, content: yourMessage}));
-            setYourMessage('');
+                JSON.stringify({roomId: roomId, content: threadMessage}));
+            setThreadMessage('');
         }
     }
 
@@ -36,7 +36,7 @@ export function MessageThread({ roomId, isOpen, close, message, handlePutPrefere
                 <div>답글</div>
                 <div className={styles.smallText}>{`${roomId}번 토론방`}</div>
             </TopNavBar>
-            <div className={styles.fixedMessageItem}>
+            <div className={styles.fixedModalBody}>
                 <MessageItem
                     message={message}
                     isThread={true}
@@ -55,9 +55,10 @@ export function MessageThread({ roomId, isOpen, close, message, handlePutPrefere
 
                 <div className={styles.bottomMargin}>
                     <BottomNavBar roomNumber={roomId}
-                                  onSendMessage={sendMessage}
-                                  message={yourMessage}
-                                  setMessage={setYourMessage}
+                                  onSendMessage={sendThreadMessage}
+                                  message={threadMessage}
+                                  setMessage={setThreadMessage}
+                                  isThread={true}
                     />
                 </div>
             </div>

--- a/src/page/DebateRoom/MessageThread/MessageThread.jsx
+++ b/src/page/DebateRoom/MessageThread/MessageThread.jsx
@@ -7,7 +7,7 @@ import {useStomp} from "../../../context/StompContext";
 import {BottomNavBar} from "../BottomNavBar/BottomNavBar";
 import {ThreadItem} from "./ThreadItem";
 
-export function MessageThread({ roomId, isOpen, close, message, handlePutPreference}){
+export function MessageThread({ roomId, isOpen, close, message, handlePutPreference, forceRefresh}){
     const stompClient = useStomp();
     const threads = useThread(message? message.messageId:null, stompClient, isOpen)
     const [threadMessage, setThreadMessage] = useState('');
@@ -18,6 +18,18 @@ export function MessageThread({ roomId, isOpen, close, message, handlePutPrefere
                 JSON.stringify({roomId: roomId, content: threadMessage}));
             setThreadMessage('');
         }
+        forceRefresh();
+    }
+
+    async function handlePutPreferenceInThread(){
+        const dto = await handlePutPreference(message.messageId, message.position)
+        let newLikesNum = message.likesNum;
+        if(dto.isIncrease){
+            newLikesNum += 1;
+        }else{
+            newLikesNum -= 1;
+        }
+        message.likesNum = newLikesNum;
     }
 
     useEffect(() => {
@@ -37,10 +49,10 @@ export function MessageThread({ roomId, isOpen, close, message, handlePutPrefere
                 <div className={styles.smallText}>{`${roomId}번 토론방`}</div>
             </TopNavBar>
             <div className={styles.fixedModalBody}>
-                <MessageItem
+                <MessageItem key={message.messageId}
                     message={message}
                     isThread={true}
-                    handlePutPreference={handlePutPreference}
+                    handlePutPreference={handlePutPreferenceInThread}
                 />
                 <div>
                     {`${threads.length}개의 답글`}

--- a/src/page/DebateRoom/MessageThread/MessageThread.jsx
+++ b/src/page/DebateRoom/MessageThread/MessageThread.jsx
@@ -1,12 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import styles from './MessageThread.module.css';
+import {TopNavBar} from "../TopNavBar/TopNavBar";
 
-export const MessageThread = ({ messageThread }) => {
+export function MessageThread({ roomId, isOpen, close, message, children }){
+    useEffect(() => {
+        if (isOpen) {
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = 'unset';
+        }
+    }, [isOpen]);
+
+    if (!isOpen) return null;
+
+
+
     return (
-        <div>
-            <p>댓글 작성자: {messageThread.writer}</p>
-            <p>댓글 내용: {messageThread.content}</p>
+        <div >
+            <TopNavBar handleOnClick={close}>
+                <div>답글</div>
+                <div className={styles.smallText}>{`${roomId}번 토론방 ${message.position}`}</div>
+            </TopNavBar>
+            <div>
+                <p>{message?.content}</p>
+                {/*<p>{message?.repliesCount}개의 댓글</p>*/}
+                {children}
+            </div>
         </div>
     );
 };
-
 

--- a/src/page/DebateRoom/MessageThread/MessageThread.module.css
+++ b/src/page/DebateRoom/MessageThread/MessageThread.module.css
@@ -1,6 +1,10 @@
 .smallText {
     font-size: small;
 }
+.modalContainer {
+    overflow-y: auto; /* 내용이 max-height를 초과할 경우 스크롤 활성화 */
+}
+
 .modalOverlay {
     position: fixed; /* 오버레이를 화면에 고정 */
     top: 0;
@@ -10,19 +14,15 @@
     background-color: rgba(255, 255, 255); /* 반투명 검은색 배경 */
 }
 
-.fixedMessageItem {
+.fixedModalBody {
     position: fixed; /* 고정 위치 */
-    top: 8%; /* 화면의 맨 위 */
+    top: 8%; /* 화면의 맨 위부터 시작 */
+    bottom: 8%; /* 화면의 맨 아래까지의 거리도 설정하여 높이를 제한 */
     width: 100%; /* 너비를 화면 전체로 설정 */
+    overflow-y: auto; /* 내부 스크롤 활성화 */
     z-index: 1000; /* 다른 요소들 위에 나타나도록 z-index 설정 */
 }
 
-.fixedCommentNum {
-    position: fixed; /* 고정 위치 */
-    top: 150px; /* 화면의 맨 위 */
-    width: 100%; /* 너비를 화면 전체로 설정 */
-    z-index: 1000; /* 다른 요소들 위에 나타나도록 z-index 설정 */
-}
 .bottomMargin {
     margin-bottom: 70px; /* 네비게이션 바의 높이만큼 패딩 추가 */
 }

--- a/src/page/DebateRoom/MessageThread/MessageThread.module.css
+++ b/src/page/DebateRoom/MessageThread/MessageThread.module.css
@@ -23,3 +23,6 @@
     width: 100%; /* 너비를 화면 전체로 설정 */
     z-index: 1000; /* 다른 요소들 위에 나타나도록 z-index 설정 */
 }
+.bottomMargin {
+    margin-bottom: 70px; /* 네비게이션 바의 높이만큼 패딩 추가 */
+}

--- a/src/page/DebateRoom/MessageThread/MessageThread.module.css
+++ b/src/page/DebateRoom/MessageThread/MessageThread.module.css
@@ -1,3 +1,25 @@
 .smallText {
     font-size: small;
 }
+.modalOverlay {
+    position: fixed; /* 오버레이를 화면에 고정 */
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255); /* 반투명 검은색 배경 */
+}
+
+.fixedMessageItem {
+    position: fixed; /* 고정 위치 */
+    top: 8%; /* 화면의 맨 위 */
+    width: 100%; /* 너비를 화면 전체로 설정 */
+    z-index: 1000; /* 다른 요소들 위에 나타나도록 z-index 설정 */
+}
+
+.fixedCommentNum {
+    position: fixed; /* 고정 위치 */
+    top: 150px; /* 화면의 맨 위 */
+    width: 100%; /* 너비를 화면 전체로 설정 */
+    z-index: 1000; /* 다른 요소들 위에 나타나도록 z-index 설정 */
+}

--- a/src/page/DebateRoom/MessageThread/MessageThread.module.css
+++ b/src/page/DebateRoom/MessageThread/MessageThread.module.css
@@ -1,0 +1,3 @@
+.smallText {
+    font-size: small;
+}

--- a/src/page/DebateRoom/MessageThread/ThreadItem.jsx
+++ b/src/page/DebateRoom/MessageThread/ThreadItem.jsx
@@ -1,0 +1,25 @@
+// Message.js 파일
+import React from 'react';
+import styles from '../MessageItem/MessageItem.module.css';
+
+export const ThreadItem = ({ thread: thread}) => {
+    return (
+        <div className={`${styles.messageContainer}`} key={thread.id}>
+            <div className={styles.header}>
+                <img src={thread.profileImage} alt="" className={styles.profileImage}/>
+                <div className={styles.flexContainer}>
+                    <div>
+                        <p className={styles.name}>{thread.writer}</p>
+                        <p className={styles.time}>{thread.createdTime}</p>
+                    </div>
+                    <p className={styles.content}>{thread.content}</p>
+                    <div className={styles.reactions}>
+                        <div className={`${styles.position}`}>
+                            {thread.position}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/page/DebateRoom/TopNavBar/TopNavBar.jsx
+++ b/src/page/DebateRoom/TopNavBar/TopNavBar.jsx
@@ -1,23 +1,20 @@
 import React from 'react';
 import { FaArrowLeft } from 'react-icons/fa';
 import styles from './TopNavBar.module.css'; // CSS 모듈 임포트
-import { useNavigate } from 'react-router-dom';
 
-export const TopNavBar = ({ roomNumber, agreeNum, disagreeNum, agreeRate, disagreeRate }) => {
-    const navigate = useNavigate();
+
+export const TopNavBar = ({handleOnClick, children }) => {
+
     return (
         <div className={styles.navBarStyle}>
             <div className={styles.itemStyle}>
-                <button onClick={() => navigate(-1)}> {/* 버튼 클릭 시 이전 페이지로 이동 */}
+                <button onClick={() => handleOnClick()}> {/* 버튼 클릭 시 이전 페이지로 이동 */}
                     <FaArrowLeft/>
                 </button>
                 <div className={styles.iconTextStyle}>
-                    <div>{`${roomNumber}번 토론방`}</div>
-                    <div className={styles.smallText}>{`찬성: ${agreeNum}명 반대: ${disagreeNum}`}</div>
+
+                    {children}
                 </div>
-            </div>
-            <div>
-                {`찬성 ${agreeRate}% / 반대 ${disagreeRate}%`}
             </div>
         </div>
     );

--- a/src/page/DebateRoom/TopNavBar/TopNavBar.module.css
+++ b/src/page/DebateRoom/TopNavBar/TopNavBar.module.css
@@ -17,11 +17,6 @@
     display: flex;
     align-items: center;
 }
-
 .iconTextStyle {
     margin-left: 10px;
-}
-
-.smallText {
-    font-size: small;
 }

--- a/src/page/DebateRoom/utils/useMessages.jsx
+++ b/src/page/DebateRoom/utils/useMessages.jsx
@@ -9,7 +9,7 @@ export const useMessages = (roomId, stompClient) => {
     const [agreeRatio, setAgreeRatio] = useState(0);
     const [disagreeRatio, setDisagreeRatio] = useState(0);
 
-    // 토론방 입장 시 찬/반 비율 보여줌 -> 수정 필요 현재 받고 있는 있는 ratio가 잘못됨(좋아요 비율이 바뀌는 중)
+    // 토론방 입장 시 찬/반 비율 보여줌
     useEffect(()=>{
         const getDebateRoomInfo = async () => {
             const dto = await fetchUtil(`/debate-room/${roomId}`, {
@@ -50,8 +50,6 @@ export const useMessages = (roomId, stompClient) => {
         const subscription = stompClient.subscribe(url, function (chat) {
             const message = JSON.parse(chat.body);
             setMessages((prevMessages) => {
-                // 메시지 객체에 새로운 메시지를 추가
-                // message.id를 키로 사용하여 메시지를 저장
                 return {
                     ...prevMessages,
                     [message.messageId]: message

--- a/src/page/DebateRoom/utils/useMessages.jsx
+++ b/src/page/DebateRoom/utils/useMessages.jsx
@@ -8,6 +8,7 @@ export const useMessages = (roomId, stompClient) => {
     const [disagreeNum, setDisagreeNum] = useState(0)
     const [agreeRatio, setAgreeRatio] = useState(0);
     const [disagreeRatio, setDisagreeRatio] = useState(0);
+    const [refreshKey, setRefreshKey] = useState(0);
 
     // 토론방 입장 시 찬/반 비율 보여줌
     useEffect(()=>{
@@ -37,7 +38,7 @@ export const useMessages = (roomId, stompClient) => {
             setMessages(messagesObject);
         };
         fetchMessages();
-    }, []);
+    }, [refreshKey]);
 
     // 해당 메세지 구독 -> 실시간 채팅 제공
     useEffect(() => {
@@ -62,9 +63,6 @@ export const useMessages = (roomId, stompClient) => {
         };
     }, [roomId, stompClient]);
 
-
-
-
     // 좋아요 추가 로직
     async function handlePutPreference(messageId, position){
         const isAgree = position !== 'DISAGREE';
@@ -77,6 +75,7 @@ export const useMessages = (roomId, stompClient) => {
 
         updateRatio(dto.ratio);
         updateLikesNum(messageId, dto.isIncrease);
+        return dto;
     }
 
     function updateRatio(ratio){
@@ -100,5 +99,9 @@ export const useMessages = (roomId, stompClient) => {
             [messageId]: { ...prevMessages[messageId], likesNum: newLikesNum }
         }));
     }
-    return { messages, agreeNum, disagreeNum, agreeRatio, disagreeRatio, handlePutPreference };
+
+    const forceRefresh = () => {
+        setRefreshKey(prevKey => prevKey + 1);
+    }
+    return { messages, agreeNum, disagreeNum, agreeRatio, disagreeRatio, handlePutPreference, forceRefresh };
 };

--- a/src/page/DebateRoom/utils/useThread.jsx
+++ b/src/page/DebateRoom/utils/useThread.jsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import { fetchUtil } from "../../../utils/fetchUtil";
+
+
+export const useThread = (messageId, stompClient, isOpen) =>{
+    const [thread, setThread] = useState([]);
+
+    // 스레드 받아오기
+    useEffect(() => {
+        if(!messageId) return;
+        const fetchMessages = async () => {
+            const dataList = await fetchUtil(`/message/thread/${messageId}`, {
+                method: 'GET'
+            });
+            setThread(dataList);
+        };
+        fetchMessages();
+    }, [messageId]);
+
+    // 해당 스레드 구독
+    useEffect(() => {
+        if(!messageId) return;
+        if (!stompClient || stompClient.connected === false) {
+            console.log('Stomp client is not connected. Attempting to reconnect...');
+            stompClient.connect();
+        }
+        const url = `/sub/room/${messageId}`;
+
+        const subscription = stompClient.subscribe(url, function (chat) {
+            const message = JSON.parse(chat.body);
+            setThread((prevThread) => {
+                return [...prevThread, message];
+            });
+        });
+
+        return () => {
+            subscription.unsubscribe();
+        };
+    }, [messageId, stompClient, isOpen]);
+
+    return thread;
+}


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- 메세지 스레드(답글) 창 구현
- 토론방 메세지 및 답글 간 상태 변화 공유
---

### ✨ 참고 사항

현재 토론방은 /room url에서 입장할 수 있어요. 1~5번까지 있는데, 
해당 id를 가진 토론방이 있어야 정상 입장 가능하니 실행 전 db에 토론방이 존재하는 지 확인해주세요

그리고 /room 은  RoomPage에서 구현하고 있는데 테스트용이라 
추후 토론방 입장이 가능한 페이지를 구현할 때 삭제하거나 수정하면 될 것 같아요.

현재 토론방에서 구현할 지 고민되는 기능이 있는데, 추가하면 좋을 지 의견 알려주시면 좋을 거 같습니다.
- 토론방 메세지 삭제 기능
- 스레드 내 답글 삭제 기능
- 토론방 내부 참여 인원 리스트 보여주기 기능

기타 추가했으면 하는 기능이 있다면 말씀해주세요!

---

### ⏰ 현재 버그

토론방에서 메세지가 추가될 때마다 스크롤을 아래로 내려주고 있는데,
'좋아요'를 클릭해도 스크롤이 내려가는 현상이 있음.
-> 수정 노력중

---

### ✏ Git Close