### PR TITLE
Fix: 로그인 요청 바닐라 Axios로 변경 및 로컬 스토리지 키 이름 변경

### DIFF
--- a/src/Provider/StompProvider.jsx
+++ b/src/Provider/StompProvider.jsx
@@ -11,7 +11,7 @@ const StompProvider = ({ children }) => {
         const socket = new SockJS(`${api}/api/ws`);
         const stompClient = Stomp.over(socket);
         const headers = {
-            'Authorization': `Bearer ${localStorage.getItem('token')}`
+            'Authorization': `Bearer ${localStorage.getItem('accessToken')}`
         };
         stompClient.connect(headers, () => {
             console.log('WebSocket Connected');

--- a/src/lib/customAxios.js
+++ b/src/lib/customAxios.js
@@ -6,7 +6,7 @@ const { REACT_APP_API_URL } = process.env;
 const customAxios = axios.create({
   baseURL: REACT_APP_API_URL + "/api",
   headers: {
-    Authorization: `Bearer ${localStorage.getItem("token")}`,
+    Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
   },
 });
 

--- a/src/page/debateRoom/utils/fetchUtil.jsx
+++ b/src/page/debateRoom/utils/fetchUtil.jsx
@@ -7,7 +7,7 @@ export async function fetchUtil(endpoint, options = {}) {
         const axiosInstance = axios.create({
             baseURL: `${api}/api`,
             headers: {
-                Authorization: `Bearer ${localStorage.getItem("token")}`,
+                Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
                 'Content-Type': 'application/json',
                 ...(options.headers || {}),
 

--- a/src/page/signup&in/SignIn.jsx
+++ b/src/page/signup&in/SignIn.jsx
@@ -2,7 +2,8 @@ import React, {useState } from "react";
 import { useNavigate } from "react-router-dom";
 import customAxios from "../../lib/customAxios";
 import styles from "./SignIn.module.css";
-
+import axios from "axios";
+const { REACT_APP_API_URL } = process.env;
 
 const SignIn = () => {
 
@@ -14,13 +15,13 @@ const SignIn = () => {
     const signInBtn = async (e) => {
         e.preventDefault();
         try {
-            const response = await customAxios.post('/account/sign-in', {
+            const response = await axios.post(REACT_APP_API_URL + '/api/account/sign-in', {
                 email, 
                 password,
             });
             if (response.status === 200) {
                 console.log('로그인 성공:', response.data);
-                localStorage.setItem('token', response.data.data.jwt)
+                localStorage.setItem('accessToken', response.data.data.jwt)
                 navToMain('/', {});
             } else {
                 console.error('로그인 실패');


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- SignIn 페이지에서 보내는 로그인 요청을 바닐라 axios로 사용
- 로그인 성공 후 받은 액세스 토큰은 localStorage에 'accessToken'를 키로 하여 저장
---

### ✨ 참고 사항

${localStorage.getItem("accessToken")}와 같이 토큰 활용하시면 됩니다.
프로젝트 내 모든 요청을 CustomAxios 하나로 통일하길 바라시면 추후에 리팩토링 진행하면 될 거 같습니다.

---

### ⏰ 현재 버그

---

### ✏ Git Close