### PR TITLE
🎨 CSS: 요약/견해 피드백,작성 페이지 전반

### DIFF
--- a/src/page/literacy/Feedback.jsx
+++ b/src/page/literacy/Feedback.jsx
@@ -17,28 +17,32 @@ const Feedback = ({state}) => {
 
     
     return (
-        <div style={{overflowY:"hidden", overflowX:"hidden"}}>
-            <h3 style={{marginLeft:"10px", marginTop:"100px"}}> AI 피드백 </h3>
+        <div style={{overflowY:"hidden", overflowX:"hidden", padding:"20px"}}>
+            <h3 style={{marginTop:"80px"}}> AI 피드백 </h3>
             <div className={styles.divBox}>
-                <h3><button className={styles.category}>{category}</button>  {title}</h3>
-                
-                <div style={{display:"flex"}}>
+                <h3 style={{wordBreak:"keep-all", lineHeight:"140%"}}><button className={styles.category}>{category}</button>  {title > 30 ? title.substr(0,30) + "..." : title}</h3>
+                <div style={{display:"flex", gap:"10px", justifyContent:"space-around"}}>
                     <div className={styles.contentBox}>
-                        <p>피드백 점수</p>
-                        <h4>{summary.score}</h4>
+                        <h4>피드백 점수</h4>
+                        <p>{summary.score}</p>
                     </div>
                     <div  className={styles.contentBox}>
-                        <p>소요 시간</p>
+                        <h4>소요 시간</h4>
                         <p>{`0${Math.floor((takenTime / 60000) % 60)}`.slice(-2)} 분 {`0${Math.floor((takenTime / 1000) % 60)}`.slice(-2)} 초</p>
+                    </div>
+                    <div className={styles.contentBox}>
+                        <h4>레벨 포인트</h4>
+                        <p>5 점</p>
                     </div>
                 </div>
                 <div className={styles.feedbackBox}>
-                    <p>피드백 내용</p>
+                    <p style={{fontWeight:"700"}}>피드백 내용</p>
                     <p>{summary.content}</p>
                 </div>
             </div>
-            <div style={{ display:"flex", margin: "5px", justifyContent:"center"}}>
-                <button className={styles.feedbackBtn} onClick={() => {navigate('/opinion-writing', {state: {data: data}})}}>견해 작성하기</button> <button className={styles.feedbackBtn} onClick={() => {navigate('/')}}>홈으로</button>
+            <div style={{display:"flex", justifyContent:"space-around"}}>
+                <button className={styles.feedbackBtn} onClick={() => {navigate('/')}}>홈으로</button>
+                <button className={styles.feedbackBtn} onClick={() => {navigate('/opinion-writing', {state: {data: data}})}}>견해 작성하기</button>
             </div>
             <BottomNavBar/>
         </div>

--- a/src/page/literacy/Feedback.module.css
+++ b/src/page/literacy/Feedback.module.css
@@ -1,35 +1,35 @@
 .divBox {
+    display: flex;
+    flex-direction: column;
     background-color: var(--color-beige);
-    margin: 10px;
-    padding: 5px;
+    padding: 12px;
     border-radius: 5px;
+    gap: 10px;
 }
 
 .feedbackBox {
-    background-color: var(--color-white);
-    margin: 5px;
-    padding: 5px;
+    background-color: var(--color-middle-grey);
+    padding: 8px;
     border-radius: 5px;
+    word-break: keep-all;
 }
 
 .contentBox {
-    background-color: var(--color-white);
-    margin: 10px;
+    background-color: var(--color-middle-grey);
     padding: 10px;
     border-radius: 5px;
+    width: 100%;
 }
 
 .category {
-    margin: 5px;
-    margin-top: 10px;
-    color: rgb(29, 198, 130);
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-xs);
     color: var(--color-white);
     background-color: var(--color-dark-grey);
     border-radius: 12px;
     pointer-events: none;
     border: none;
     padding: 8px;
+    margin-right: 10px;
 }
 
 .feedbackBtn {
@@ -39,13 +39,10 @@
     border-radius: 5px;
     padding: 10px;
     cursor: pointer;
-    margin: 10px;
+    margin-bottom: 20%;
+    width: 40%;
+    min-width:fit-content;
+    margin-top: 15px;
+    
 }
 
-.positionDiv {
-    background-color: var(--color-white);
-    margin: 10px;
-    padding: 10px;
-    border-radius: 5px;
-    justify-content: center;
-}

--- a/src/page/literacy/OpinionFeedback.jsx
+++ b/src/page/literacy/OpinionFeedback.jsx
@@ -11,30 +11,29 @@ const OpinionFeedback = ({state}) => {
     const opinion = location.state?.opinion;
     const position = location.state?.position;
     const category = location.state?.category;
+    const articleId = location.state?.articleId;
 
   const navigate = useNavigate();
 
     
     return (
-        <div style={{overflowY:"hidden", overflowX:"hidden"}}>
-            <h3 style={{marginLeft:"10px", marginTop:"100px"}}> AI 피드백 </h3>
+        <div style={{overflowY:"hidden",overflowX:"hidden", padding:"20px"}}>
+            <h3 style={{marginTop:"80px"}}> AI 피드백 </h3>
             <div className={styles.divBox}>
-                <h3><button className={styles.category}>{category}</button>  {title}</h3>
-                
-                <div style={{display:"flex"}}>
-                    <div className={styles.positionDiv}>
-                        <p >입장</p>
-                        <p style={{fontWeight:"600"}}>{position}</p>
+                <h3 style={{wordBreak:"keep-all", lineHeight:"140%"}}><button className={styles.category}>{category}</button>  {title > 30 ? title.substr(0,30) + "..." : title}</h3>
+                <h5>나의 입장 : {position}</h5>
+                    <div className={styles.feedbackBox}>
+                        <h4>견해 작성 내용</h4>
+                        <p>{opinion.content}</p>
                     </div>
-            
-                </div>
                 <div className={styles.feedbackBox}>
-                    <p>피드백 내용</p>
+                    <h4>피드백 내용</h4>
                     <p>{opinion.feedbackContent}</p>
                 </div>
             </div>
-            <div style={{ display:"flex", margin: "5px", justifyContent:"center"}}>
+            <div style={{display:"flex", justifyContent:"space-around"}}>
                 <button className={styles.feedbackBtn} onClick={() => {navigate('/')}}>홈으로</button>
+                <button className={styles.feedbackBtn} onClick={() => {navigate(`/debate-room/${articleId}`)}}>토론방 입장</button>
             </div>
             <BottomNavBar/>
         </div>

--- a/src/page/literacy/OpinionWriting.jsx
+++ b/src/page/literacy/OpinionWriting.jsx
@@ -38,7 +38,7 @@ const OpinionWriting = () => {
           width: "300px",
           confirmButtonColor: "#B5C9C0",
         }).then(() => {
-          navigate("/opinion-feedback", {state: {opinion: response.data.data, title : location.title, category: location.category, position: position}});
+          navigate("/opinion-feedback", {state: {opinion: response.data.data, title : location.title, category: location.category, position: position, articleId: location.id}});
 
         })
       }
@@ -65,7 +65,7 @@ const OpinionWriting = () => {
     if (isWaitingOpinion) return <p>피드백을 기다리는 중입니다.</p>
 
     return (
-        <div style={{overflow:"hidden"}}>
+        <div style={{overflow:"hidden", display:"flex", flexDirection:"column", gap:"10px",padding:"20px"}}>
             <div className={styles.articleDiv}>
                 <h2 className={styles.title}>{location.title}</h2>
                 <h4>{formatDateTime(location.createdTime)}</h4>

--- a/src/page/literacy/SummaryWriting.jsx
+++ b/src/page/literacy/SummaryWriting.jsx
@@ -8,8 +8,8 @@ import Swal from "sweetalert2";
 const SummaryWriting = () => {
   const location = useLocation().state.data;
   const navigate = useNavigate();
-  const [summaryHistory, setSummaryHistory] = useState([]);
-  const [summary, setSummary] = useState([]);
+  const [summaryHistory, setSummaryHistory] = useState(null);
+  const [summary, setSummary] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isWaitingFeedback, setIsWaitingFeedback] = useState(false);
   const [time, setTime] = useState(0)
@@ -167,7 +167,7 @@ const SummaryWriting = () => {
     if (isWaitingFeedback) return <p>피드백을 기다리는 중입니다.</p>
 
     return (
-        <div style={{overflow:"hidden"}}>
+        <div style={{overflow:"hidden", display:"flex", flexDirection:"column", gap:"10px",padding:"20px"}}>
             <div className={styles.articleDiv}>
                 <h2 className={styles.title}>{location.title}</h2>
                 <h4>{formatDateTime(location.createdTime)}</h4>

--- a/src/page/literacy/SummaryWriting.module.css
+++ b/src/page/literacy/SummaryWriting.module.css
@@ -22,7 +22,7 @@
 
 .title {
     margin-bottom: 0px;
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-lg);
 }
 
 .category {
@@ -32,7 +32,7 @@
 }
 
 .content {
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     line-height: 24px;
     color: #537768;
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- CSS 수정 완료
- 견해 피드백까지 완료 후 해당 기사 토론방으로 입장할 수 있는 버튼 추가 // 이를 위해 articleID를 기사 리스트에서부터 요약 작성 -> 요약 피드백 -> 견해 작성 -> 견해 피드백까지 전달함
- `[]` -> `null` 로 처리

---

### ✨ 참고 사항

---

### ⏰ 현재 버그
- 토론방 이동 시 props가 없음
---

### ✏ Git Close #71